### PR TITLE
a couple fixes

### DIFF
--- a/src/main/java/ennuo/craftworld/types/mods/Mod.java
+++ b/src/main/java/ennuo/craftworld/types/mods/Mod.java
@@ -64,7 +64,7 @@ public class Mod extends FileData {
     
     private void process(File file) {
         this.isParsed = false;
-        try (FileSystem fileSystem = FileSystems.newFileSystem(file.toPath(), null)) {
+        try (FileSystem fileSystem = FileSystems.newFileSystem(file.toPath(), (java.lang.ClassLoader) null)) {
             Path configPath = fileSystem.getPath("config.json");
             if (!Files.exists(configPath)) {
                 System.err.println("Mod is missing config.json!");

--- a/src/main/java/ennuo/toolkit/utilities/EasterEgg.java
+++ b/src/main/java/ennuo/toolkit/utilities/EasterEgg.java
@@ -43,6 +43,11 @@ public class EasterEgg {
             toolkit.debugMenu.setVisible(true);
         }
 
+        if (username.equals("madbrine")) { //metraberryy, feel free to remove this if you want
+            toolkit.setTitle("farctool3");
+            toolkit.debugMenu.setVisible(true);
+        }
+
         if (toolkit.debugMenu.isVisible()) {
             toolkit.setTitle(toolkit.getTitle() + " | Debug");
             Flags.ENABLE_NEW_SAVEDATA = true;

--- a/src/main/java/ennuo/toolkit/windows/Toolkit.java
+++ b/src/main/java/ennuo/toolkit/windows/Toolkit.java
@@ -1919,6 +1919,7 @@ public class Toolkit extends javax.swing.JFrame {
 
     private void loadSavedataActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_loadSavedataActionPerformed
         String directory = FileChooser.openDirectory();
+        if (directory == null) return;
         if (directory.isEmpty()) return;
         FileSave save = new FileSave(new File(directory));
         this.addTab(save);


### PR DESCRIPTION
fixes labeled by commits

newfilesystem is ambiguous in java 13+, cast null to java.lang.ClassLoader to be safe
loadsavedata directory is null if closed without choosing a directory, return if null to avoid errors

and easteregg title for me :> you can remove that if you want though