### PR TITLE
Use Best Compression

### DIFF
--- a/src/main/java/ennuo/craftworld/utilities/Compressor.java
+++ b/src/main/java/ennuo/craftworld/utilities/Compressor.java
@@ -11,7 +11,7 @@ import java.util.zip.Inflater;
 public class Compressor {
     public static byte[] deflateData(byte[] data) {
         try {
-            Deflater deflater = new Deflater();
+            Deflater deflater = new Deflater(9);
             ByteArrayOutputStream stream = new ByteArrayOutputStream(data.length);
             deflater.setInput(data);
             deflater.finish();


### PR DESCRIPTION
Toolkit currently uses the default zlib compression type which is not accurate to LittleBigPlanet, this PR changes it to use compression type 9 (best compression), which is 1:1 with LittleBigPlanet's compressed files, and results in smaller file sizes. 

Not sure if this was intentional or not, but if so, perhaps consider making the compression types configurable from within the GUI instead.