### PR TITLE
Add LWJGL profiles for Linux ARM64

### DIFF
--- a/lib/cwlib-gl/pom.xml
+++ b/lib/cwlib-gl/pom.xml
@@ -25,6 +25,18 @@
 
     <profiles>
         <profile>
+            <id>lwjgl-natives-linux-aarch64</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <lwjgl.natives>natives-linux-arm64</lwjgl.natives>
+            </properties>
+        </profile>
+        <profile>
             <id>lwjgl-natives-linux-amd64</id>
             <activation>
                 <os>

--- a/toolkit/pom.xml
+++ b/toolkit/pom.xml
@@ -24,6 +24,18 @@
 
     <profiles>
         <profile>
+            <id>lwjgl-natives-linux-aarch64</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <lwjgl.natives>natives-linux-arm64</lwjgl.natives>
+            </properties>
+        </profile>
+        <profile>
             <id>lwjgl-natives-linux-amd64</id>
             <activation>
                 <os>


### PR DESCRIPTION
Here's a PR for issue #29, adding an LWJGL profile to the right `pom.xml` files for Linux on ARM devices. From my testing, the toolkit works perfectly, didn't return any errors when compiling or running it.

There are also natives for Windows x86 listed on [LWJGL downloads](https://www.lwjgl.org/browse/stable/bin/lwjgl), which might also be good to add, however I don't have a way to test compiling with them at the moment.

Not sure if there are natives for Linux x86, perhaps the one listed on the site is universal.