### PR TITLE
Convert emitter parent rotation angle from radians to degrees when backporting

### DIFF
--- a/lib/cwlib/src/main/java/cwlib/structs/things/parts/PEmitter.java
+++ b/lib/cwlib/src/main/java/cwlib/structs/things/parts/PEmitter.java
@@ -306,12 +306,14 @@ public class PEmitter implements Serializable
                     
                     worldOffset = parentRelativeOffset.mul(parentMatrix.transpose(new Matrix4f()), new Vector4f());
                     worldOffset.w = 0.0f;
-
+                    
                     // Not the best at Matrix math, so this'll do
-                    float parentRotationRadians = (float)Math.toRadians(parentRelativeRotation);
-                    Matrix4f worldRotationMatrix = parentMatrix.rotateZ(parentRotationRadians, new Matrix4f());
+                    Matrix4f worldRotationMatrix = parentMatrix.rotateZ(parentRelativeRotation, new Matrix4f());
                     Vector3f worldEulerAngles = worldRotationMatrix.getNormalizedRotation(new Quaternionf()).getEulerAnglesXYZ(new Vector3f());
                     worldRotation = (float)Math.toDegrees(worldEulerAngles.z);
+
+                    // Convert parent rotation from radians to degrees
+                    parentRelativeRotation = (float)Math.toDegrees(parentRelativeRotation);
                 }
             }
         }


### PR DESCRIPTION
The existing code assumed that the rotation angle was already stored in degrees, however in LBP3 this is not the case, so the angle must be converted from radians. World rotation logic was also wrong since it was attempting to convert the value that was already in radians into radians again; this is also fixed.